### PR TITLE
Rules for rrd files and luci-statistics

### DIFF
--- a/src/agent/rpcd.cil
+++ b/src/agent/rpcd.cil
@@ -220,6 +220,9 @@
        (call .uci.manage_conffile_files (subj))
        (call .uci.read_tmpfile_files (subj))
 
+       (call .luci.read_datafile_files (subj))
+       (call .luci.list_datafile_dirs (subj))
+
        (call .uhttpd.getattr_execfile_files (subj))
 
        (call .upgrade.read_miscfile_files (subj))
@@ -244,6 +247,11 @@
 
        (optional rpcd_opt_rcfirewall
                  (call .rcfirewall.subj_type_transition (subj)))
+
+       (optional rpcd_opt_rrd
+                 (call .rrd.list_tmpfile_dirs (subj))
+                 (call .rrd.read_tmpfile_files (subj))
+                 (call .rrd.read_tmpfile_lnk_files (subj)))
 
        (optional rpcd_opt_sqm
                  (call .sqm.getattr_execfile_files (subj))

--- a/src/agent/rrd.cil
+++ b/src/agent/rrd.cil
@@ -1,0 +1,54 @@
+;; -*- mode: CIL; fill-column: 79; indent-tabs-mode: nil; -*-
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in .file
+    (call .rrd.obj_type_transition_tmpfile (unconfined.subj_typeattr))
+    (call .rrd.rrdtool.obj_type_transition_execfile
+          (unconfined.subj_typeattr)))
+
+(block rrd
+
+    (filecon
+     "/tmp/rrd"
+     dir
+     tmpfile_file_context)
+    (filecon
+     "/tmp/rrd/.*"
+     any
+     tmpfile_file_context)
+
+
+    (macro obj_type_transition_tmpfile ((type ARG1))
+           (call .tmp.fs_obj_type_transition
+                 (ARG1 tmpfile dir "rrd")))
+
+    (blockinherit .tmpfile.obj_template)
+    
+    (block rrdtool
+    
+           ;;
+           ;; Contexts
+           ;;
+
+           (filecon
+            "/usr/bin/rrdtool"
+            file
+            execfile_file_context)
+
+           ;;
+           ;; Macros
+           ;;
+
+           (macro obj_type_transition_execfile ((type ARG1))
+                  (call .file.execfile_obj_type_transition
+                        (ARG1 execfile file "rrdtool")))
+
+           (macro execute_execfile_files ((type ARG1))
+              (allow ARG1 execfile execute_file))
+
+           ;;
+           ;; Policy
+           ;;
+
+           (blockinherit file.exec.obj_template)))

--- a/src/cgiscript/cgiio.cil
+++ b/src/cgiscript/cgiio.cil
@@ -64,6 +64,9 @@
        (call .file.read_conffile_lnk_files (subj))
        (call .file.search_initscriptfile_dirs (subj))
 
+       (call .luci.read_datafile_files (subj))
+       (call .luci.list_datafile_dirs (subj))
+
        (call .locale.read.subj_type (subj))
 
        (call .logread.subj_type_transition (subj))
@@ -92,4 +95,10 @@
                  (call .mtd.read_stordev_blk_files (subj)))
 
        (optional cgiio_opt_rcfirewall
-                 (call .rcfirewall.subj_type_transition (subj))))
+                 (call .rcfirewall.subj_type_transition (subj)))
+
+       (optional cgiio_opt_rrd
+                     (call .rrd.list_tmpfile_dirs (subj))
+                     (call .rrd.read_tmpfile_files (subj))
+                     (call .rrd.read_tmpfile_lnk_files (subj))
+                     (call .rrd.rrdtool.execute_execfile_files (subj))))


### PR DESCRIPTION
Definition of rrd and rrdtool
Allow cgi-io and rpcd to access rdd tmpfiles
Allow cgi-io and rpcd to access luci datafiles (required for plugin definition in luci-statistics)
Allow cgi-io to execute rrdtool without a domain transition
