### PR TITLE
rrd.cil related

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ modules = $(shell find src -type f -name '*.cil' \
 modulesnoluci = $(shell find src -type f -name '*.cil' \
 	-regextype posix-egrep \
 	! -regex 'src/(cgi|init)?script/.*\.cil' \
-	! -name luci.cil ! -name rpcd.cil ! -name uhttpd.cil \
+	! -name luci.cil ! -name rpcd.cil ! -name rrd.cil ! -name uhttpd.cil \
 	-printf '%p ')
 
 # my own customised target, tailored to my personal requirements
@@ -30,7 +30,7 @@ modulesmintesttgt = $(shell find src -type f -name '*.cil' \
 	! -name luci.cil ! -name mmcstordev.cil \
 	! -name nvmestordev.cil ! -name nvramnodedev.cil \
 	! -name px5gexecfile.cil \
-	! -name rpcd.cil ! -name sftpserver.cil \
+	! -name rpcd.cil ! -name rrd.cil ! -name sftpserver.cil \
 	! -name srstordev.cil ! -name squid.cil \
 	! -name uhttpd.cil ! -name vdstordev.cil \
 	! -name vmcinodedev.cil -printf '%p ')

--- a/src/agent/rrd.cil
+++ b/src/agent/rrd.cil
@@ -2,6 +2,9 @@
 ;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
 ;; SPDX-License-Identifier: Unlicense
 
+(in .sys
+    (call .rrd.rrdtool.subj_type_transition (subj)))
+
 (in .file
     (call .rrd.obj_type_transition_tmpfile (unconfined.subj_typeattr))
     (call .rrd.rrdtool.obj_type_transition_execfile


### PR DESCRIPTION
exclude rrd.cil from the noluci make target

make sys.subj transition to rrd.rrdtool.subj automatically
This is currently broken as there are no rules associated with rrd.rrdtool.subj
i guess we'll address that when we get to it/
